### PR TITLE
fix wrong last row class under tree mode

### DIFF
--- a/demo/TreeGridDemo.jsx
+++ b/demo/TreeGridDemo.jsx
@@ -165,6 +165,7 @@ class Demo extends React.Component {
       useListActionBar: true,
       showColumnPickerCheckAll: true,
       showColumnPicker: true,
+      columnResizeable: true,
       actionBar: {
         columnsOrder: {
           iconName: 'huxiangguanzhu',
@@ -273,7 +274,6 @@ class Demo extends React.Component {
       },
       jsxcolumns: this.state.columns,
       renderModel: 'tree',
-      columnResizeable: false,
       toggleTreeExpandOnRowClick: true,
       rowSelection: {
         onSelect: (checked, selectedRow, selectedRows) => {

--- a/demo/data.json
+++ b/demo/data.json
@@ -239,7 +239,7 @@
       }
     ],
     "currentPage": 1,
-    "totalCount": 30
+    "totalCount": 300
   },
   "success": true,
   "errorCode": "",

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -17,9 +17,9 @@ import Demo5 from './TableGroup';
 import Demo6 from './TableRowGroup';
 import '../style';
 
-// ReactDOM.render(<Demo />, document.getElementById('UXCoreDemo'));
+ReactDOM.render(<Demo />, document.getElementById('UXCoreDemo'));
 // ReactDOM.render(<Demo2 />, document.getElementById('UXCoreDemo2'));
-ReactDOM.render(<Demo3 />, document.getElementById('UXCoreDemo3'));
+// ReactDOM.render(<Demo3 />, document.getElementById('UXCoreDemo3'));
 // ReactDOM.render(<Demo4 />, document.getElementById('UXCoreDemo4'));
 // ReactDOM.render(<Demo5 />, document.getElementById('UXCoreDemo5'));
 // ReactDOM.render(<Demo6 />, document.getElementById('UXCoreDemo6'));

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -17,9 +17,9 @@ import Demo5 from './TableGroup';
 import Demo6 from './TableRowGroup';
 import '../style';
 
-ReactDOM.render(<Demo />, document.getElementById('UXCoreDemo'));
+// ReactDOM.render(<Demo />, document.getElementById('UXCoreDemo'));
 // ReactDOM.render(<Demo2 />, document.getElementById('UXCoreDemo2'));
-// ReactDOM.render(<Demo3 />, document.getElementById('UXCoreDemo3'));
+ReactDOM.render(<Demo3 />, document.getElementById('UXCoreDemo3'));
 // ReactDOM.render(<Demo4 />, document.getElementById('UXCoreDemo4'));
 // ReactDOM.render(<Demo5 />, document.getElementById('UXCoreDemo5'));
 // ReactDOM.render(<Demo6 />, document.getElementById('UXCoreDemo6'));

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "uxcore-formatter": "^0.1.2",
     "uxcore-icon": "^0.1.10",
     "uxcore-menu": "^4.0.0",
-    "uxcore-pagination": "^0.7.0",
+    "uxcore-pagination": "^0.8.0",
     "uxcore-popover": "^0.6.0",
     "uxcore-radiogroup": "^1.2.0",
     "uxcore-select2": "^0.5.0",

--- a/src/Row.jsx
+++ b/src/Row.jsx
@@ -130,8 +130,16 @@ class Row extends React.Component {
       return children;
     }
     if (props.rowData.data) {
-      const needEmptyIconIntree = !!props.rowData.data.filter(item => item.data).length;
-      props.rowData.data.forEach((node, index) => {
+      const subRowData = props.rowData.data;
+      const needEmptyIconIntree = !!subRowData.filter(item => item.data).length;
+      subRowData.forEach((node, index) => {
+        const isLastItem = index === subRowData.length - 1;
+
+        let last = props.isParentLast && isLastItem;
+        if ({}.hasOwnProperty.call(node, 'data') && node.data.length > 0) {
+          last = false;
+        }
+
         const renderProps = assign({}, props, {
           level: me.props.level + 1,
           index,
@@ -141,6 +149,8 @@ class Row extends React.Component {
           key: node.jsxid,
           showSubComp: false,
           visible: (props.expandedKeys.indexOf(props.rowData.jsxid) !== -1),
+          last,
+          isParentLast: isLastItem,
           needEmptyIconIntree,
         });
         children.push(<Row {...renderProps} />);
@@ -379,6 +389,7 @@ Row.propTypes = {
   rowSelection: PropTypes.object,
   showSubComp: PropTypes.bool,
   last: PropTypes.bool,
+  isParentLast: PropTypes.bool,
   visible: PropTypes.bool,
   isHover: PropTypes.bool,
   level: PropTypes.number,
@@ -406,6 +417,7 @@ Row.defaultProps = {
   isHover: undefined,
   visible: undefined,
   last: undefined,
+  isParentLast: undefined,
   rowSelection: undefined,
   rowData: undefined,
   root: undefined,

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -1052,7 +1052,6 @@ class Table extends React.Component {
     });
   }
 
-
   static getDerivedStateFromProps = (props, state) => {
     let newData = {};
     if (props.pageSize !== state.lastPageSize) {
@@ -1187,10 +1186,7 @@ class Table extends React.Component {
     );
   }
 
-
-
   renderPager(miniType) {
-
     const me = this;
     const { data, currentPage, pageSize } = this.state;
     const {
@@ -1473,7 +1469,7 @@ class Table extends React.Component {
       onColumnFilter: this.handleFilter,
       key: 'table-header',
       columnResizeable: props.columnResizeable,
-      handleColumnResize: this.handleColumnResize
+      handleColumnResize: this.handleColumnResize,
     };
 
     const renderFooterProps = {

--- a/src/Tbody.jsx
+++ b/src/Tbody.jsx
@@ -275,8 +275,17 @@ class Tbody extends React.Component {
     if (props.renderModel === 'tree') {
       needEmptyIconIntree = !!data.filter(rowData => rowData.data).length;
     }
+
     if (!this.props.rowGroupKey) {
       rows = data.map((item, index) => {
+        const isLastItem = index === data.length - 1;
+
+        // 如果是树形模式并且当前行有子行且子行属于展开状态，不要加 last 样式
+        let last = isLastItem;
+        if ({}.hasOwnProperty.call(item, 'data') && item.data.length > 0) {
+          last = false;
+        }
+
         const renderProps = {
           ...commonProps,
           index,
@@ -287,7 +296,8 @@ class Tbody extends React.Component {
           ref: (c) => {
             this[`row${index}`] = c;
           },
-          last: (index === data.length - 1),
+          last,
+          isParentLast: isLastItem,
           needEmptyIconIntree,
         };
         return <Row {...renderProps} />;
@@ -316,11 +326,20 @@ class Tbody extends React.Component {
         }
         this.rowGroupMap[rowGroupName].items.push(item);
       }
+
       rows = (
         <Collapse activeKey={props.rowGroupActiveKey || '0'} className={`${props.prefixCls}-collapse`} onChange={(key, activeKey) => { props.onCollapseChange(activeKey); }}>
           {this.rowGroupArr.map((rowGroupName, i) => (
             <Collapse.Panel header={this.getRowGroupName(rowGroupName)} key={i}>
               {this.rowGroupMap[rowGroupName].items.map((item, j) => {
+                const isLastItem = i === this.rowGroupArr.length - 1 && j === this.rowGroupMap[rowGroupName].items.length - 1;
+
+                // 如果是树形模式并且当前行有子行且子行属于展开状态，不要加 last 样式
+                let last = isLastItem;
+                if ({}.hasOwnProperty.call(item, 'data') && item.data.length > 0) {
+                  last = false;
+                }
+
                 const index = `${i}-${j}`;
                 const renderProps = {
                   ...commonProps,
@@ -332,8 +351,8 @@ class Tbody extends React.Component {
                   ref: (c) => {
                     this[`row${index}`] = c;
                   },
-                  last: i === this.rowGroupArr.length - 1
-                    && j === this.rowGroupMap[rowGroupName].length - 1,
+                  last,
+                  isParentLast: isLastItem,
                 };
                 return <Row {...renderProps} />;
               })}
@@ -343,6 +362,7 @@ class Tbody extends React.Component {
         </Collapse>
       );
     }
+
     return (
       <div className={bodyWrapClassName} ref={this.saveRef('root')} style={style}>
         {this.renderEmptyData()}

--- a/src/Tbody.jsx
+++ b/src/Tbody.jsx
@@ -269,7 +269,7 @@ class Tbody extends React.Component {
       tablePrefixCls: props.tablePrefixCls,
       visible: true,
       bodyNode: this.root,
-      getTooltipContainer: props.getTooltipContainer
+      getTooltipContainer: props.getTooltipContainer,
     };
     let needEmptyIconIntree = false;
     if (props.renderModel === 'tree') {

--- a/src/style/Header.less
+++ b/src/style/Header.less
@@ -49,6 +49,10 @@
     border-radius: 0;
     min-width: 104px;
     max-width: 232px;
+
+    .@{__checkbox-prefix-cls}-item {
+      margin-bottom: 0;
+    }
   }
   .@{__dropdownPrefixCls}-menu-sub {
     border: 1px solid @border-color;

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -15,6 +15,7 @@
 @__collapsePrefixCls: kuma-collapse;
 @__selectPrefixCls: kuma-select2;
 @__calendarPrefixCls: kuma-calendar;
+@__checkbox-prefix-cls: kuma-checkbox-group;
 
 @import "./ActionBar.less";
 @import "./Mask.less";


### PR DESCRIPTION
1. 最后一行会有添加一个 last 样式的特性避免底部的双 border，但是在 treeMode 下最后一行的判断逻辑是不对的，会导致第一层的最后一行在展开后都没有了间隔线。（另外在之前的 group 状态下，last 的判断逻辑是错的，直接拿了 `this.rowGroupMap[rowGroupName]` 的 length 做计算，应该是 `this.rowGroupMap[rowGroupName].items`）

> 修正逻辑：把上一层是否为最后一行通过 isParentLast 递归传递下去，如果发现 当前行 和 父行均为最后一行且子行未被展开，再加上 last 样式

2. 列筛选的 dropdown 中有使用 uxcore-checkbox-group，这个组件在表单域场景中有一个默认的 12px 下边距，放在这个场景导致样式很怪，因此覆盖掉了

3. 随手改了几个 eslint 的问题，未全改